### PR TITLE
日報のデザイン修正

### DIFF
--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -27,7 +27,6 @@
               <div class="form-row">
                 <div class="col-3 col-md-3">ジャンル</div>
                 <div class="col-6 col-md-8">やったこと</div>
-                <div class="col-1 col-md-1">-</div>
               </div>
               <div id="report_items">
                   <%= f.fields_for :report_items do |item| %>

--- a/app/views/reports/_report_item_fields.erb
+++ b/app/views/reports/_report_item_fields.erb
@@ -1,14 +1,14 @@
-<div class="form-row nested-fields">
-    <div class="my-2 col-3 col-md-3">
-			<%= f.text_field :genre_name ,{:class => 'form-control' ,:list => 'datalistOptions3', :id => 'exampleDataList3' , :value => get_genre_name(f.object.genre_id) } %>
+<div class="form-row nested-fields mb-4">
+    <div class="my-2 col-6 col-md-3">
+			<%= f.text_field :genre_name ,{:class => 'form-control form-control-sm w-100' ,:list => 'datalistOptions3', :id => 'exampleDataList3' , :value => get_genre_name(f.object.genre_id) ,:placeholder => "ジャンル"} %>
 			<datalist id="datalistOptions3">
 			<% @select_genre.each do |genre| %>
 				<option value= <%= genre.name %> >
 			<% end %>
 			</datalist>
     </div>
-		<div class="my-2 col-8 col-md-8">
-    	<%= f.text_field :content,class: "form-control form-control-sm w-100"%>
+		<div class="my-2 col-11 col-md-8">
+    	<%= f.text_field :content,{class: "form-control form-control-sm w-100" ,:placeholder => "やったことを記載"} %>
 		</div>
     <div class="col-1 col-md-1 d-flex justify-content-center align-items-center">
 			<%= link_to_remove_association "", f  ,\


### PR DESCRIPTION
日報を記録する画面が、スマホの時は入力しづらい。

ジャンルの枠を広げた。
フォームの初期値を設けて、どこに何を入力すればいいかわかりやすくした。