### PR TITLE
navbar中央揃え

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -108,7 +108,7 @@
 
 .img-logo {
   width:300px;
-  padding: 20px 40px;
+  padding: 20px;
 }
 
 .bold-r {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,11 +29,11 @@
   
   <%= render "layouts/flash" %>
 
-  <nav class="navbar navbar-expand-sm navbar-light bg-light gnav">
-    <div id="logo">
+  <nav class="navbar d-flex flex-column flex-md-row navbar-expand-sm navbar-light bg-light gnav">
+    <div id="logo" class = "col">
     <%= link_to image_tag('/logo.png', class:"img-logo"), plans_path %>
     </div>
-    <div class="navbar" id="navbarNavDropdown">
+    <div class="navbar col-auto" id="navbarNavDropdown">
       <ul class="navbar-nav">
         <% if user_signed_in? %>
           <li class="nav-item <%= 'active' if @active_menu == 'reports' %>">
@@ -64,9 +64,6 @@
           </li>
           <li class="nav-item">
             <%= link_to "ログイン", new_user_session_path ,class: "nav-link2" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post ,class: "nav-link2" %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
ロゴをスマホで表示する際は中央に寄せた。
ゲストログインの文字はページ中央にすでにあるのでナビバーからは消した。