### PR TITLE
本番環境のデプロイエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
     "dayjs": "^1.11.7",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
-    "turbolinks": "^5.2.0"
-  },
-  "version": "0.1.0",
-  "devDependencies": {
+    "turbolinks": "^5.2.0",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-transform-private-property-in-object": "^7.27.1"
-  }
+  },
+  "version": "0.1.0",
+  "devDependencies": {}
 }


### PR DESCRIPTION
Render.comへデプロイすると以下のエラーが発生した


```
[0] ./app/javascript/packs/application.js 4.21 KiB {0} [built] [failed] [1 error]
ERROR in ./app/javascript/packs/application.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find package '@babel/plugin-proposal-private-methods' imported from /opt/render/project/src/babel-virtual-resolve-base.js
```

これを解決するために、devDependencyの中身を変更した。